### PR TITLE
Poc each interface

### DIFF
--- a/iprange.go
+++ b/iprange.go
@@ -61,7 +61,6 @@ func IPRange2CIDR(startIP, endIP net.IP) []net.IPNet {
 }
 
 // EachIPRange2CIDR execute the callback for each CIDR for the provided IP range.
-// Return 0 if IP order is wrong
 func EachIPRange2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) {
 	if startIPv4, endIPv4 := startIP.To4(), endIP.To4(); startIPv4 != nil && endIPv4 != nil {
 		EachIPv4Range2CIDR(startIPv4, endIPv4, callback)

--- a/iprange.go
+++ b/iprange.go
@@ -62,20 +62,19 @@ func IPRange2CIDR(startIP, endIP net.IP) []net.IPNet {
 
 // EachIPRange2CIDR execute the callback for each CIDR for the provided IP range.
 // Return 0 if IP order is wrong
-func EachIPRange2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) int {
+func EachIPRange2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) {
 	if startIPv4, endIPv4 := startIP.To4(), endIP.To4(); startIPv4 != nil && endIPv4 != nil {
-		return EachIPv4Range2CIDR(startIPv4, endIPv4, callback)
+		EachIPv4Range2CIDR(startIPv4, endIPv4, callback)
+	} else {
+		EachIPv6Range2CIDR(startIP.To16(), endIP.To16(), callback)
 	}
-
-	return EachIPv6Range2CIDR(startIP.To16(), endIP.To16(), callback)
-
 }
 
 // IPv4Range2CIDR returns a slice of CIDR for the provided IPv4 range.
 // Returns nil if IP order is wrong
 // Returns nil if provided IPs are not IPv4
 func IPv4Range2CIDR(startIP, endIP net.IP) (ipNetSlice []net.IPNet) {
-	_ = EachIPv4Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
+	EachIPv4Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
 		ipNetSlice = append(ipNetSlice, cidr)
 	})
 
@@ -86,7 +85,7 @@ func IPv4Range2CIDR(startIP, endIP net.IP) (ipNetSlice []net.IPNet) {
 // Returns nil if IP order is wrong
 // Returns nil if provided IPs are not IPv4
 func IPv6Range2CIDR(startIP, endIP net.IP) (ipNetSlice []net.IPNet) {
-	_ = EachIPv6Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
+	EachIPv6Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
 		ipNetSlice = append(ipNetSlice, cidr)
 	})
 
@@ -95,25 +94,25 @@ func IPv6Range2CIDR(startIP, endIP net.IP) (ipNetSlice []net.IPNet) {
 
 // EachIPv4Range2CIDR will execute the callback parameter with each CIDR
 // for the provided IPv4 range
-// Returns the number of CIDRs generated
-// Returns 0 if IP order is wrong
-// Returns 0 if provided IPs are not IPv4
-func EachIPv4Range2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) int {
+func EachIPv4Range2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) {
 	// Ensure IPs are IPV4
 	startIP, endIP = startIP.To4(), endIP.To4()
 	if startIP == nil || endIP == nil {
-		return 0
+		return
 	}
 
 	// Convert to uint32
 	start := IPv4ToUint32(startIP)
 	end := IPv4ToUint32(endIP)
 	if start > end {
-		return 0
+		return
 	}
 
-	var zeroBits, currentBits, n int
-	var cidr net.IPNet
+	var (
+		zeroBits    int
+		currentBits int
+		cidr        net.IPNet
+	)
 	for start <= end {
 		zeroBits = bits.TrailingZeros32(start)
 
@@ -124,35 +123,32 @@ func EachIPv4Range2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) int {
 		callback(cidr)
 
 		start += 1 << uint(currentBits)
-		n++
 	}
-
-	return n
 }
 
 // EachIPv6Range2CIDR will execute the callback parameter with each CIDR
 // for the provided IPv6 range
-// Returns the number of CIDRs generated
-// Returns 0 if IP order is wrong
-// Returns 0 if provided IPs are not IPv6
-func EachIPv6Range2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) int {
+func EachIPv6Range2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) {
 	// Ensure IPs are IPV6
 	if len(startIP) != net.IPv6len || len(endIP) != net.IPv6len {
-		return 0
+		return
 	}
 
 	// Convert to uint128
 	start := IPv6ToUint128(startIP)
 	end := IPv6ToUint128(endIP)
 	if start.Cmp(end) > 0 {
-		return 0
+		return
 	}
 
 	// TODO: Find number of CIDRs for a given address range and preallocate slice
 	// Worst case is ipNetSlice = make([]net.IPNet, 0, 128*2-2)
 	// QUESTION: Some way to preallocate net.IP and net.CIDRMask as well?
-	var zeroBits, currentBits, n int
-	var cidr net.IPNet
+	var (
+		zeroBits    int
+		currentBits int
+		cidr        net.IPNet
+	)
 	for start.Cmp(end) <= 0 {
 		zeroBits = uint128.TrailingZeros(start)
 
@@ -164,8 +160,5 @@ func EachIPv6Range2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) int {
 		callback(cidr)
 
 		start = start.Add(uint128.Incr(uint128.Zero()).ShiftLeft(uint(currentBits)))
-		n++
 	}
-
-	return n
 }

--- a/iprange_test.go
+++ b/iprange_test.go
@@ -108,6 +108,16 @@ func TestIPv4Range2CIDR(t *testing.T) {
 			label:    "IPRange2CIDR",
 			getRange: cidr.IPRange2CIDR,
 		},
+		{
+			label: "EachIPv4Range2CIDR",
+			getRange: func(startIP, endIP net.IP) []net.IPNet {
+				var cidrs []net.IPNet
+				_ = cidr.EachIPv4Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
+					cidrs = append(cidrs, cidr)
+				})
+				return cidrs
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -303,6 +313,13 @@ func BenchmarkIPv4Range2CIDR(b *testing.B) {
 		b.Run(fmt.Sprintf("Range_%s-%s", benchmarkCase.startIP, benchmarkCase.endIP), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				cidrs = cidr.IPv4Range2CIDR(benchmarkCase.startIP, benchmarkCase.endIP)
+			}
+		})
+		b.Run(fmt.Sprintf("Range_%s-%s-each", benchmarkCase.startIP, benchmarkCase.endIP), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				cidr.EachIPv4Range2CIDR(benchmarkCase.startIP, benchmarkCase.endIP, func(r net.IPNet) {
+					_ = r
+				})
 			}
 		})
 	}

--- a/iprange_test.go
+++ b/iprange_test.go
@@ -118,6 +118,16 @@ func TestIPv4Range2CIDR(t *testing.T) {
 				return cidrs
 			},
 		},
+		{
+			label: "EachIPRange2CIDR",
+			getRange: func(startIP, endIP net.IP) []net.IPNet {
+				var cidrs []net.IPNet
+				_ = cidr.EachIPRange2CIDR(startIP, endIP, func(cidr net.IPNet) {
+					cidrs = append(cidrs, cidr)
+				})
+				return cidrs
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -206,6 +216,27 @@ func TestIPv6Range2CIDR(t *testing.T) {
 		{
 			label:           "IPRange2CIDR",
 			getRange:        cidr.IPRange2CIDR,
+			mayReturn32bits: true,
+		},
+		{
+			label: "EachIPv6Range2CIDR",
+			getRange: func(startIP, endIP net.IP) []net.IPNet {
+				var cidrs []net.IPNet
+				_ = cidr.EachIPv6Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
+					cidrs = append(cidrs, cidr)
+				})
+				return cidrs
+			},
+		},
+		{
+			label: "EachIPRange2CIDR",
+			getRange: func(startIP, endIP net.IP) []net.IPNet {
+				var cidrs []net.IPNet
+				_ = cidr.EachIPRange2CIDR(startIP, endIP, func(cidr net.IPNet) {
+					cidrs = append(cidrs, cidr)
+				})
+				return cidrs
+			},
 			mayReturn32bits: true,
 		},
 	}
@@ -315,7 +346,7 @@ func BenchmarkIPv4Range2CIDR(b *testing.B) {
 				cidrs = cidr.IPv4Range2CIDR(benchmarkCase.startIP, benchmarkCase.endIP)
 			}
 		})
-		b.Run(fmt.Sprintf("Range_%s-%s-each", benchmarkCase.startIP, benchmarkCase.endIP), func(b *testing.B) {
+		b.Run(fmt.Sprintf("Each/Range_%s-%s", benchmarkCase.startIP, benchmarkCase.endIP), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				cidr.EachIPv4Range2CIDR(benchmarkCase.startIP, benchmarkCase.endIP, func(r net.IPNet) {
 					_ = r
@@ -353,6 +384,13 @@ func BenchmarkIPv6Range2CIDR(b *testing.B) {
 		b.Run(fmt.Sprintf("Range_%s-%s", benchmarkCase.startIP, benchmarkCase.endIP), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				cidrs = cidr.IPv6Range2CIDR(benchmarkCase.startIP, benchmarkCase.endIP)
+			}
+		})
+		b.Run(fmt.Sprintf("Each/Range_%s-%s", benchmarkCase.startIP, benchmarkCase.endIP), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				cidr.EachIPv6Range2CIDR(benchmarkCase.startIP, benchmarkCase.endIP, func(r net.IPNet) {
+					_ = r
+				})
 			}
 		})
 	}

--- a/iprange_test.go
+++ b/iprange_test.go
@@ -112,7 +112,7 @@ func TestIPv4Range2CIDR(t *testing.T) {
 			label: "EachIPv4Range2CIDR",
 			getRange: func(startIP, endIP net.IP) []net.IPNet {
 				var cidrs []net.IPNet
-				_ = cidr.EachIPv4Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
+				cidr.EachIPv4Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
 					cidrs = append(cidrs, cidr)
 				})
 				return cidrs
@@ -122,7 +122,7 @@ func TestIPv4Range2CIDR(t *testing.T) {
 			label: "EachIPRange2CIDR",
 			getRange: func(startIP, endIP net.IP) []net.IPNet {
 				var cidrs []net.IPNet
-				_ = cidr.EachIPRange2CIDR(startIP, endIP, func(cidr net.IPNet) {
+				cidr.EachIPRange2CIDR(startIP, endIP, func(cidr net.IPNet) {
 					cidrs = append(cidrs, cidr)
 				})
 				return cidrs
@@ -222,7 +222,7 @@ func TestIPv6Range2CIDR(t *testing.T) {
 			label: "EachIPv6Range2CIDR",
 			getRange: func(startIP, endIP net.IP) []net.IPNet {
 				var cidrs []net.IPNet
-				_ = cidr.EachIPv6Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
+				cidr.EachIPv6Range2CIDR(startIP, endIP, func(cidr net.IPNet) {
 					cidrs = append(cidrs, cidr)
 				})
 				return cidrs
@@ -232,7 +232,7 @@ func TestIPv6Range2CIDR(t *testing.T) {
 			label: "EachIPRange2CIDR",
 			getRange: func(startIP, endIP net.IP) []net.IPNet {
 				var cidrs []net.IPNet
-				_ = cidr.EachIPRange2CIDR(startIP, endIP, func(cidr net.IPNet) {
+				cidr.EachIPRange2CIDR(startIP, endIP, func(cidr net.IPNet) {
 					cidrs = append(cidrs, cidr)
 				})
 				return cidrs


### PR DESCRIPTION
Hello

I add one function who does not create an slice of CIDRs, but uses a callback.

this is my case in geoloc grpc server.

this is faster and perform less allocations than the regular interface

next steps:

1. generate an IPv6 version
2. refactor old function to use this new function to append into a slice

```
$ go test -v  -bench=. -run=XXX -benchmem  ./... 
goos: linux
goarch: amd64
pkg: github.com/weborama/cidr
BenchmarkIPv4ToUint32-4     	1000000000	         2.67 ns/op	       0 B/op	       0 allocs/op
BenchmarkIPv6ToUint128-4    	500000000	         2.99 ns/op	       0 B/op	       0 allocs/op
BenchmarkUint32ToIPv4-4     	100000000	        14.0 ns/op	       4 B/op	       1 allocs/op
BenchmarkUint128ToIPv6-4    	50000000	        25.5 ns/op	      16 B/op	       1 allocs/op
BenchmarkIPv4Range2CIDR/Range_0.0.0.0-0.0.0.1-4         	10000000	       138 ns/op	      56 B/op	       3 allocs/op
BenchmarkIPv4Range2CIDR/Range_0.0.0.0-0.0.0.1-each-4    	20000000	        76.2 ns/op	       8 B/op	       2 allocs/op
BenchmarkIPv4Range2CIDR/Range_0.0.0.1-255.255.255.254-4 	  300000	      5053 ns/op	    6592 B/op	     131 allocs/op
BenchmarkIPv4Range2CIDR/Range_0.0.0.1-255.255.255.254-each-4         	  500000	      2757 ns/op	     496 B/op	     124 allocs/op
BenchmarkIPv6Range2CIDR/Range_0.0.0.0-0.0.0.1-4                      	10000000	       158 ns/op	      80 B/op	       3 allocs/op
BenchmarkIPv6Range2CIDR/Range_0.0.0.1-255.255.255.254-4              	  200000	      6974 ns/op	    8080 B/op	     131 allocs/op
BenchmarkIPv6Range2CIDR/Range_::1-ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe-4         	   50000	     26786 ns/op	   32656 B/op	     517 allocs/op
PASS
ok  	github.com/weborama/cidr	18.391s
```