### PR TITLE
Change each interface to handle numeric representation of id instead net.ip

### DIFF
--- a/iprange.go
+++ b/iprange.go
@@ -87,16 +87,13 @@ func AdaptCallbackToIPv6(callback func(net.IPNet)) func(uint128.Uint128, int, in
 // EachIPRange2CIDR execute the callback for each CIDR for the provided IP range.
 func EachIPRange2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) {
 	if startIPv4, endIPv4 := startIP.To4(), endIP.To4(); startIPv4 != nil && endIPv4 != nil {
-		// Convert to uint32
-		start := IPv4ToUint32(startIP)
-		end := IPv4ToUint32(endIP)
+		start := IPv4ToUint32(startIPv4)
+		end := IPv4ToUint32(endIPv4)
 
 		EachIPv4Range2CIDR(start, end, AdaptCallbackToIPv4(callback))
-
 	} else if startIPv6, endIPv6 := startIP.To16(), endIP.To16(); startIPv6 != nil && endIPv6 != nil {
-		// Convert to uint128
-		start := IPv6ToUint128(startIP)
-		end := IPv6ToUint128(endIP)
+		start := IPv6ToUint128(startIPv6)
+		end := IPv6ToUint128(endIPv6)
 
 		EachIPv6Range2CIDR(start, end, AdaptCallbackToIPv6(callback))
 	}

--- a/iprange.go
+++ b/iprange.go
@@ -87,9 +87,18 @@ func AdaptCallbackToIPv6(callback func(net.IPNet)) func(uint128.Uint128, int, in
 // EachIPRange2CIDR execute the callback for each CIDR for the provided IP range.
 func EachIPRange2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) {
 	if startIPv4, endIPv4 := startIP.To4(), endIP.To4(); startIPv4 != nil && endIPv4 != nil {
-		EachIPv4Range2CIDR(startIPv4, endIPv4, AdaptCallbackToIPv4(callback))
-	} else {
-		EachIPv6Range2CIDR(startIP.To16(), endIP.To16(), AdaptCallbackToIPv6(callback))
+		// Convert to uint32
+		start := IPv4ToUint32(startIP)
+		end := IPv4ToUint32(endIP)
+
+		EachIPv4Range2CIDR(start, end, AdaptCallbackToIPv4(callback))
+
+	} else if startIPv6, endIPv6 := startIP.To16(), endIP.To16(); startIPv6 != nil && endIPv6 != nil {
+		// Convert to uint128
+		start := IPv6ToUint128(startIP)
+		end := IPv6ToUint128(endIP)
+
+		EachIPv6Range2CIDR(start, end, AdaptCallbackToIPv6(callback))
 	}
 }
 
@@ -97,7 +106,17 @@ func EachIPRange2CIDR(startIP, endIP net.IP, callback func(net.IPNet)) {
 // Returns nil if IP order is wrong
 // Returns nil if provided IPs are not IPv4
 func IPv4Range2CIDR(startIP, endIP net.IP) (ipNetSlice []net.IPNet) {
-	EachIPv4Range2CIDR(startIP, endIP, func(ip uint32, ones, bits int) {
+	// Ensure IPs are IPv4
+	startIP, endIP = startIP.To4(), endIP.To4()
+	if startIP == nil || endIP == nil {
+		return
+	}
+
+	// Convert to uint32
+	start := IPv4ToUint32(startIP)
+	end := IPv4ToUint32(endIP)
+
+	EachIPv4Range2CIDR(start, end, func(ip uint32, ones, bits int) {
 		ipNetSlice = append(ipNetSlice, net.IPNet{
 			IP:   Uint32ToIPv4(ip),
 			Mask: net.CIDRMask(ones, bits),
@@ -111,7 +130,17 @@ func IPv4Range2CIDR(startIP, endIP net.IP) (ipNetSlice []net.IPNet) {
 // Returns nil if IP order is wrong
 // Returns nil if provided IPs are not IPv4
 func IPv6Range2CIDR(startIP, endIP net.IP) (ipNetSlice []net.IPNet) {
-	EachIPv6Range2CIDR(startIP, endIP, func(ip uint128.Uint128, ones, bits int) {
+	// Ensure IPs are IPv6
+	startIP, endIP = startIP.To16(), endIP.To16()
+	if startIP == nil || endIP == nil {
+		return
+	}
+
+	// Convert to uint128
+	start := IPv6ToUint128(startIP)
+	end := IPv6ToUint128(endIP)
+
+	EachIPv6Range2CIDR(start, end, func(ip uint128.Uint128, ones, bits int) {
 		ipNetSlice = append(ipNetSlice, net.IPNet{
 			IP:   Uint128ToIPv6(ip),
 			Mask: net.CIDRMask(ones, bits),
@@ -123,17 +152,7 @@ func IPv6Range2CIDR(startIP, endIP net.IP) (ipNetSlice []net.IPNet) {
 
 // EachIPv4Range2CIDR will execute the callback parameter with each CIDR
 // for the provided IPv4 range
-func EachIPv4Range2CIDR(startIP, endIP net.IP, callback func(ip uint32, ones, bits int)) {
-	// Ensure IPs are IPV4
-	startIP, endIP = startIP.To4(), endIP.To4()
-	if startIP == nil || endIP == nil {
-		return
-	}
-
-	// Convert to uint32
-	start := IPv4ToUint32(startIP)
-	end := IPv4ToUint32(endIP)
-
+func EachIPv4Range2CIDR(start, end uint32, callback func(ip uint32, ones, bits int)) {
 	if start > end {
 		return
 	}
@@ -156,16 +175,7 @@ func EachIPv4Range2CIDR(startIP, endIP net.IP, callback func(ip uint32, ones, bi
 
 // EachIPv6Range2CIDR will execute the callback parameter with each CIDR
 // for the provided IPv6 range
-func EachIPv6Range2CIDR(startIP, endIP net.IP, callback func(ip uint128.Uint128, ones, bits int)) {
-	// Ensure IPs are IPV6
-	if len(startIP) != net.IPv6len || len(endIP) != net.IPv6len {
-		return
-	}
-
-	// Convert to uint128
-	start := IPv6ToUint128(startIP)
-	end := IPv6ToUint128(endIP)
-
+func EachIPv6Range2CIDR(start, end uint128.Uint128, callback func(ip uint128.Uint128, ones, bits int)) {
 	if start.Cmp(end) > 0 {
 		return
 	}

--- a/iprange_test.go
+++ b/iprange_test.go
@@ -114,8 +114,11 @@ func TestIPv4Range2CIDR(t *testing.T) {
 		{
 			label: "EachIPv4Range2CIDR",
 			getRange: func(startIP, endIP net.IP) []net.IPNet {
+				start := cidr.IPv4ToUint32(startIP)
+				end := cidr.IPv4ToUint32(endIP)
+
 				var cidrs []net.IPNet
-				cidr.EachIPv4Range2CIDR(startIP, endIP, cidr.AdaptCallbackToIPv4(func(cidr net.IPNet) {
+				cidr.EachIPv4Range2CIDR(start, end, cidr.AdaptCallbackToIPv4(func(cidr net.IPNet) {
 					cidrs = append(cidrs, cidr)
 				}))
 				return cidrs
@@ -225,8 +228,11 @@ func TestIPv6Range2CIDR(t *testing.T) {
 		{
 			label: "EachIPv6Range2CIDR",
 			getRange: func(startIP, endIP net.IP) []net.IPNet {
+				start := cidr.IPv6ToUint128(startIP)
+				end := cidr.IPv6ToUint128(endIP)
+
 				var cidrs []net.IPNet
-				cidr.EachIPv6Range2CIDR(startIP, endIP, cidr.AdaptCallbackToIPv6(func(cidr net.IPNet) {
+				cidr.EachIPv6Range2CIDR(start, end, cidr.AdaptCallbackToIPv6(func(cidr net.IPNet) {
 					cidrs = append(cidrs, cidr)
 				}))
 				return cidrs
@@ -366,13 +372,17 @@ func BenchmarkIPv4Range2CIDR(b *testing.B) {
 		b.Run(fmt.Sprintf("Each/Range_%s-%s", benchmarkCase.startIP, benchmarkCase.endIP), func(b *testing.B) {
 			var ip uint32
 			var ones, bits int
+			start := cidr.IPv4ToUint32(benchmarkCase.startIP)
+			end := cidr.IPv4ToUint32(benchmarkCase.endIP)
 			for n := 0; n < b.N; n++ {
-				cidr.EachIPv4Range2CIDR(benchmarkCase.startIP, benchmarkCase.endIP, func(_ip uint32, _ones, _bits int) {
+				cidr.EachIPv4Range2CIDR(start, end, func(_ip uint32, _ones, _bits int) {
 					ip = _ip
 					ones = _ones
 					bits = _bits
 				})
 			}
+			_ = start
+			_ = end
 			_ = ip
 			_ = ones
 			_ = bits
@@ -416,13 +426,18 @@ func BenchmarkIPv6Range2CIDR(b *testing.B) {
 		b.Run(fmt.Sprintf("Each/Range_%s-%s", benchmarkCase.startIP, benchmarkCase.endIP), func(b *testing.B) {
 			var ip uint128.Uint128
 			var ones, bits int
+			start := cidr.IPv6ToUint128(benchmarkCase.startIP)
+			end := cidr.IPv6ToUint128(benchmarkCase.endIP)
+
 			for n := 0; n < b.N; n++ {
-				cidr.EachIPv6Range2CIDR(benchmarkCase.startIP, benchmarkCase.endIP, func(_ip uint128.Uint128, _ones, _bits int) {
+				cidr.EachIPv6Range2CIDR(start, end, func(_ip uint128.Uint128, _ones, _bits int) {
 					ip = _ip
 					ones = _ones
 					bits = _bits
 				})
 			}
+			_ = start
+			_ = end
 			_ = ip
 			_ = ones
 			_ = bits


### PR DESCRIPTION
since we read uint32 values from sqlite, does not make sense convert to an net.IP, just to convert it back

using this interface (with pure numerical version) instead using net.IPs avoid an extra conversion.

we can consider add an intermediate interface later.